### PR TITLE
feat: add backup-monitor-crawler IAM role

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,12 +69,17 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [aws_iam_policy.backup_monitor_crawler_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.dai_data_crawler_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role.backup_monitor_crawler](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.dai_data_crawler](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.terraform_execution](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.attach_backup_monitor_crawler_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.attach_data_crawler_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.terraform_execution_policies](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.backup_monitor_crawler_assume_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.backup_monitor_crawler_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.dai_data_crawler_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.dai_lens_data_crawler_assume_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.terraform_execution_assume_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -83,6 +88,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_backup_monitor_crawler"></a> [backup\_monitor\_crawler](#input\_backup\_monitor\_crawler) | Configuration for the backup monitor crawler IAM role and permissions.<br/><br/>- create            : Whether to create the IAM role and policies.<br/>- nameprefix        : Prefix for the IAM role name and policy.<br/>- trusted\_role\_arns : List of ARNs for roles that can assume this role (e.g. the backup monitor Lambda execution role). | <pre>object({<br/>    create            = optional(bool, false)<br/>    nameprefix        = optional(string, "")<br/>    trusted_role_arns = optional(list(string), [])<br/>  })</pre> | `{}` | no |
 | <a name="input_dai_lens_data_crawler"></a> [dai\_lens\_data\_crawler](#input\_dai\_lens\_data\_crawler) | Configuration for the DAI Lens data crawler IAM role and permissions"<br/><br/>- create                : Whether to create the IAM role and policies.<br/>- nameprefix            : Prefix for the IAM role name and policy.<br/>- disable\_rds\_access    : If true, disables access to RDS resources.<br/>- disable\_health\_access : If true, disables access to AWS Health resources.<br/>- trusted\_role\_arns     : List of ARNs for roles that can assume this role. | <pre>object({<br/>    create                = optional(bool, false)<br/>    nameprefix            = optional(string, "")<br/>    disable_rds_access    = optional(bool, false)<br/>    disable_health_access = optional(bool, false)<br/>    trusted_role_arns     = optional(list(string), [])<br/>  })</pre> | `{}` | no |
 | <a name="input_terraform_execution_role"></a> [terraform\_execution\_role](#input\_terraform\_execution\_role) | Configuration for the Terraform execution IAM role. This role is assumed by<br/>GitHub Actions OIDC roles to run Terraform, separating authentication from authorization.<br/><br/>- create                        : Whether to create the IAM role (default: true).<br/>- github\_actions\_oidc\_role\_name : Name of the GitHub Actions OIDC role in the current account (default: "cicd-iac").<br/>- external\_trusted\_arns         : List of external role ARNs that can assume this role (cross-account access).<br/>- policy\_arns                   : List of managed policy ARNs to attach.<br/>- permissions\_boundary          : ARN of permissions boundary policy (optional). | <pre>object({<br/>    create                        = optional(bool, true)<br/>    github_actions_oidc_role_name = optional(string, "cicd-iac")<br/>    external_trusted_arns         = optional(list(string), [])<br/>    policy_arns                   = optional(list(string), ["arn:aws:iam::aws:policy/AdministratorAccess"])<br/>    permissions_boundary          = optional(string, null)<br/>  })</pre> | `{}` | no |
 
@@ -90,6 +96,7 @@ No modules.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_backup_monitor_crawler"></a> [backup\_monitor\_crawler](#output\_backup\_monitor\_crawler) | Values for the backup monitor crawler IAM role |
 | <a name="output_dai_data_crawler"></a> [dai\_data\_crawler](#output\_dai\_data\_crawler) | values for the DAI Lens data crawler IAM role |
 | <a name="output_terraform_execution"></a> [terraform\_execution](#output\_terraform\_execution) | Values for the Terraform execution IAM role |
 <!-- END_TF_DOCS -->

--- a/README.md
+++ b/README.md
@@ -6,13 +6,30 @@ This module provides some global IAM Roles and Policies to be used across single
 
 ```tf
 module "global_roles" {
-  source  = "tx-pts-dai/global-roles/aws
-  version = "1.0.0
+  source  = "tx-pts-dai/global-roles/aws"
+  version = "~> 1.0"
 
+  # Terraform Execution Role (enabled by default)
+  terraform_execution_role = {
+    github_actions_oidc_role_name = "cicd-iac"
+    policy_arns = [
+      "arn:aws:iam::aws:policy/AdministratorAccess",
+    ]
+  }
+
+  # Backup Monitor Crawler Role (disabled by default)
+  backup_monitor_crawler = {
+    create = true
+    trusted_role_arns = [
+      "arn:aws:iam::<ACCOUNT_ID>:role/<ROLE_NAME>",
+    ]
+  }
+
+  # DAI Lens Data Crawler Role (disabled by default)
   dai_lens_data_crawler = {
     create = true
     trusted_role_arns = [
-      "arn:aws:iam::<ACCOUNT_ID>:role/<ROLE_NAME>"
+      "arn:aws:iam::<ACCOUNT_ID>:role/<ROLE_NAME>",
     ]
   }
 }
@@ -107,4 +124,4 @@ Module is maintained by [Alfredo Gottardo](https://github.com/AlfGot), [David Be
 
 ## License
 
-Apache 2 Licensed. See [LICENSE](< link to license file >) for full details.
+Apache 2 Licensed. See [LICENSE](LICENSE) for full details.

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ No modules.
 
 ## Authors
 
-Module is maintained by [Alfredo Gottardo](https://github.com/AlfGot), [David Beauvererd](https://github.com/Davidoutz), [Davide Cammarata](https://github.com/DCamma), [Francisco Ferreira](https://github.com/cferrera),  [Roland Bapst](https://github.com/rbapst-tamedia) and [Samuel Wibrow](https://github.com/swibrow)
+Module is maintained by [Alfredo Gottardo](https://github.com/AlfGot), [David Beauvererd](https://github.com/Davidoutz), [Davide Cammarata](https://github.com/DCamma), [Francisco Ferreira](https://github.com/cferrera),  [Roland Bapst](https://github.com/rbapst-tamedia), [Samuel Wibrow](https://github.com/swibrow) and [Christian Jürges](https://github.com/chrisamti)
 
 ## License
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -46,6 +46,16 @@ module "global_roles" {
     # permissions_boundary = "arn:aws:iam::123456789012:policy/TerraformBoundary"
   }
 
+  # Backup Monitor Crawler Role (disabled by default)
+  backup_monitor_crawler = {
+    create = true
+
+    # Allow the backup monitor Lambda execution role to assume this role
+    trusted_role_arns = [
+      # "arn:aws:iam::123456789012:role/backup-monitor-lambda-role",
+    ]
+  }
+
   # DAI Lens Data Crawler Role (disabled by default)
   dai_lens_data_crawler = {
     create = true

--- a/main.tf
+++ b/main.tf
@@ -1,4 +1,79 @@
 #
+## Backup Monitor Crawler
+data "aws_iam_policy_document" "backup_monitor_crawler_assume_role_policy" {
+  count = var.backup_monitor_crawler.create ? 1 : 0
+
+  dynamic "statement" {
+    for_each = var.backup_monitor_crawler.trusted_role_arns
+
+    content {
+      effect  = "Allow"
+      actions = ["sts:AssumeRole"]
+      principals {
+        type        = "AWS"
+        identifiers = [statement.value]
+      }
+    }
+  }
+}
+
+resource "aws_iam_role" "backup_monitor_crawler" {
+  count = var.backup_monitor_crawler.create ? 1 : 0
+
+  name        = "${var.backup_monitor_crawler.nameprefix}backup-monitor-crawler"
+  description = "Grants the backup monitor Lambda read access to RDS, Backup, and KMS resources"
+
+  assume_role_policy = data.aws_iam_policy_document.backup_monitor_crawler_assume_role_policy[0].json
+}
+
+data "aws_iam_policy_document" "backup_monitor_crawler_policy" {
+  count = var.backup_monitor_crawler.create ? 1 : 0
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "rds:DescribeDBInstances",
+      "rds:DescribeDBClusters",
+      "rds:ListTagsForResource",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "backup:ListBackupJobs",
+      "backup:ListCopyJobs",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "kms:DescribeKey",
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "backup_monitor_crawler_policy" {
+  count = var.backup_monitor_crawler.create ? 1 : 0
+
+  name        = "${var.backup_monitor_crawler.nameprefix}backup-monitor-crawler"
+  description = "Read-only access to RDS, Backup, and KMS for the backup monitor crawler"
+
+  policy = data.aws_iam_policy_document.backup_monitor_crawler_policy[0].json
+}
+
+resource "aws_iam_role_policy_attachment" "attach_backup_monitor_crawler_policy" {
+  count = var.backup_monitor_crawler.create ? 1 : 0
+
+  role       = aws_iam_role.backup_monitor_crawler[0].name
+  policy_arn = aws_iam_policy.backup_monitor_crawler_policy[0].arn
+}
+
+#
 ## DAI Lens Data Crawler
 data "aws_iam_policy_document" "dai_lens_data_crawler_assume_role_policy" {
   count = var.dai_lens_data_crawler.create ? 1 : 0

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,11 @@
+output "backup_monitor_crawler" {
+  description = "Values for the backup monitor crawler IAM role"
+  value = var.backup_monitor_crawler.create ? {
+    role_name = aws_iam_role.backup_monitor_crawler[0].name
+    role_arn  = aws_iam_role.backup_monitor_crawler[0].arn
+  } : null
+}
+
 output "dai_data_crawler" {
   description = "values for the DAI Lens data crawler IAM role"
   value = var.dai_lens_data_crawler.create ? {

--- a/tests/backup_monitor_crawler.tftest.hcl
+++ b/tests/backup_monitor_crawler.tftest.hcl
@@ -1,0 +1,130 @@
+mock_provider "aws" {
+  override_data {
+    target = data.aws_iam_policy_document.backup_monitor_crawler_assume_role_policy[0]
+    values = {
+      json = <<-JSON
+        {
+          "Version": "2012-10-17",
+          "Statement": [{
+            "Effect": "Allow",
+            "Principal": { "AWS": "arn:aws:iam::123456789012:role/backup-monitor-lambda-role" },
+            "Action": "sts:AssumeRole"
+          }]
+        }
+      JSON
+    }
+  }
+
+  override_data {
+    target = data.aws_iam_policy_document.backup_monitor_crawler_policy[0]
+    values = {
+      json = <<-JSON
+        {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Action": ["rds:DescribeDBInstances", "rds:DescribeDBClusters", "rds:ListTagsForResource"],
+              "Resource": "*"
+            },
+            {
+              "Effect": "Allow",
+              "Action": ["backup:ListBackupJobs", "backup:ListCopyJobs"],
+              "Resource": "*"
+            },
+            {
+              "Effect": "Allow",
+              "Action": ["kms:DescribeKey"],
+              "Resource": "*"
+            }
+          ]
+        }
+      JSON
+    }
+  }
+}
+
+variables {
+  terraform_execution_role = {
+    create = false
+  }
+}
+
+run "does_not_create_by_default" {
+  command = plan
+
+  assert {
+    condition     = length(aws_iam_role.backup_monitor_crawler) == 0
+    error_message = "Role should not be created by default"
+  }
+}
+
+run "creates_role_when_enabled" {
+  command = plan
+
+  variables {
+    backup_monitor_crawler = {
+      create = true
+    }
+  }
+
+  assert {
+    condition     = aws_iam_role.backup_monitor_crawler[0].name == "backup-monitor-crawler"
+    error_message = "Role name should be 'backup-monitor-crawler'"
+  }
+}
+
+run "creates_role_with_prefix" {
+  command = plan
+
+  variables {
+    backup_monitor_crawler = {
+      create     = true
+      nameprefix = "prod-"
+    }
+  }
+
+  assert {
+    condition     = aws_iam_role.backup_monitor_crawler[0].name == "prod-backup-monitor-crawler"
+    error_message = "Role name should include prefix"
+  }
+}
+
+run "creates_policy" {
+  command = plan
+
+  variables {
+    backup_monitor_crawler = {
+      create = true
+    }
+  }
+
+  assert {
+    condition     = aws_iam_policy.backup_monitor_crawler_policy[0].name == "backup-monitor-crawler"
+    error_message = "Policy should be created"
+  }
+}
+
+run "outputs_role_info" {
+  command = plan
+
+  variables {
+    backup_monitor_crawler = {
+      create = true
+    }
+  }
+
+  assert {
+    condition     = output.backup_monitor_crawler != null
+    error_message = "Output should not be null when role is created"
+  }
+}
+
+run "outputs_null_when_disabled" {
+  command = plan
+
+  assert {
+    condition     = output.backup_monitor_crawler == null
+    error_message = "Output should be null when role is not created"
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,20 @@
+variable "backup_monitor_crawler" {
+  description = <<-EOT
+    Configuration for the backup monitor crawler IAM role and permissions.
+
+    - create            : Whether to create the IAM role and policies.
+    - nameprefix        : Prefix for the IAM role name and policy.
+    - trusted_role_arns : List of ARNs for roles that can assume this role (e.g. the backup monitor Lambda execution role).
+  EOT
+
+  type = object({
+    create            = optional(bool, false)
+    nameprefix        = optional(string, "")
+    trusted_role_arns = optional(list(string), [])
+  })
+  default = {}
+}
+
 variable "dai_lens_data_crawler" {
   description = <<-EOT
     Configuration for the DAI Lens data crawler IAM role and permissions"


### PR DESCRIPTION
Implements the backup-monitor-crawler role following the same pattern as dai_lens_data_crawler, granting spoke accounts read access to RDS, Backup, and KMS so the shared-backups-monitoring Lambda can assume it cross-account.