### PR TITLE
fix: use tag:GetResources backup-monitor-crawler policy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -34,6 +34,13 @@ data "aws_iam_policy_document" "backup_monitor_crawler_policy" {
     actions = [
       "rds:DescribeDBInstances",
       "rds:DescribeDBClusters",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
       "tag:GetResources",
     ]
     resources = ["*"]

--- a/main.tf
+++ b/main.tf
@@ -34,7 +34,7 @@ data "aws_iam_policy_document" "backup_monitor_crawler_policy" {
     actions = [
       "rds:DescribeDBInstances",
       "rds:DescribeDBClusters",
-      "rds:ListTagsForResource",
+      "tag:GetResources",
     ]
     resources = ["*"]
   }

--- a/tests/backup_monitor_crawler.tftest.hcl
+++ b/tests/backup_monitor_crawler.tftest.hcl
@@ -24,7 +24,12 @@ mock_provider "aws" {
           "Statement": [
             {
               "Effect": "Allow",
-              "Action": ["rds:DescribeDBInstances", "rds:DescribeDBClusters", "tag:GetResources"],
+              "Action": ["rds:DescribeDBInstances", "rds:DescribeDBClusters"],
+              "Resource": "*"
+            },
+            {
+              "Effect": "Allow",
+              "Action": ["tag:GetResources"],
               "Resource": "*"
             },
             {

--- a/tests/backup_monitor_crawler.tftest.hcl
+++ b/tests/backup_monitor_crawler.tftest.hcl
@@ -24,7 +24,7 @@ mock_provider "aws" {
           "Statement": [
             {
               "Effect": "Allow",
-              "Action": ["rds:DescribeDBInstances", "rds:DescribeDBClusters", "rds:ListTagsForResource"],
+              "Action": ["rds:DescribeDBInstances", "rds:DescribeDBClusters", "tag:GetResources"],
               "Resource": "*"
             },
             {


### PR DESCRIPTION
## Summary

- Replaces `rds:ListTagsForResource` with `tag:GetResources` in the `backup-monitor-crawler` IAM policy
- The backup monitor Lambda fetches tags via a single bulk `tag:GetResources` call per account, not per-resource `rds:ListTagsForResource` calls
- Fixes `AccessDeniedException` seen in spoke accounts using this module